### PR TITLE
Cleans up testGetRemoteFileGoesToCurrentDirectory()

### DIFF
--- a/src/test/java/FTPCommandsTest.java
+++ b/src/test/java/FTPCommandsTest.java
@@ -338,6 +338,7 @@ public class FTPCommandsTest {
         commands.getRemoteFile(ftp, fileToGrab.getName());
 
         File localGrabbedFile = new File(localDirectory, fileToGrab.getName());
+        localGrabbedFile.deleteOnExit();
 
         assertTrue(localGrabbedFile.exists());
     }


### PR DESCRIPTION
I noticed this test wasn't deleting it's test file after getting if from the server. Fixed.